### PR TITLE
The reshape package is required for the melt function

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -14,7 +14,8 @@ Depends:
     RCurl,
     png,
     ggplot2 (>= 0.9.2.1),
-    RJSONIO
+    RJSONIO,
+    reshape
 Collate:
     'metrics.R'
     'metrics_methods.R'


### PR DESCRIPTION
I have added a dependency on the reshape package, which the 'melt' function is from. Without this, the altmetric functions errored on my clean R install.
