### PR TITLE
Fix typo in user-agent

### DIFF
--- a/R/metrics.R
+++ b/R/metrics.R
@@ -77,7 +77,7 @@ altmetrics <-
     base_url <- "http://api.altmetric.com/v1/"
     args <- list(key = apikey)
     request <-
-      httr::GET(paste0(base_url, ids), query = args, foptions, httr::add_headers("user-agent" = "#rstats rAltmertic package https://github.com/ropensci/rAltmetric"))
+      httr::GET(paste0(base_url, ids), query = args, foptions, httr::add_headers("user-agent" = "#rstats rAltmetric package https://github.com/ropensci/rAltmetric"))
     if(httr::status_code(request) == 404) {
     stop("No metrics found for object")
     } else {


### PR DESCRIPTION
While looking for an example of user-agent I've found a typo in the user-agent specified by `rAltmetric` ;)